### PR TITLE
日付の問題解消

### DIFF
--- a/src/components/BroadcastCard.tsx
+++ b/src/components/BroadcastCard.tsx
@@ -9,15 +9,15 @@ import {
 export type TCard = {
   id: string
   title: string
-  updated_at: string
+  stream_date: string
   is_streamed: number
   hee_count: number
 }
 
 export const BroadcastCard: VFC<TCard> = ({
   title,
-  updated_at,
   is_streamed,
+  stream_date,
   hee_count
 }) => {
   const statusText = useMemo(() => {
@@ -43,7 +43,7 @@ export const BroadcastCard: VFC<TCard> = ({
                 icon={faCalendarWeek}
               />
             </figure>
-            <span className="ml-[8px] text-gray-400">{updated_at}</span>
+            <span className="ml-[8px] text-gray-400">{stream_date}</span>
           </div>
         </div>
         <div className="flex flex-col items-end">

--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -2,6 +2,7 @@ import { BroadcastCard } from 'components/BroadcastCard'
 import { getStreams } from 'lib/streamImpl'
 import { useEffect, useState } from 'react'
 import type { TCard } from 'components/BroadcastCard'
+import { formatDate } from 'utils/formatDate'
 
 export const initialState: TCard[] = []
 
@@ -13,13 +14,16 @@ export const Broadcasts: React.VFC = () => {
     ;(async (): void => {
       try {
         const streams = await getStreams()
-        streams.forEach((stream) => {
+        const docs = streams.docs.map((stream) => {
+          const streamDate = formatDate(stream.data().stream_date.toDate())
           const data = {
             ...stream.data(),
-            id: stream.id
+            id: stream.id,
+            stream_date: streamDate
           }
-          setCastsArray((prev) => [...prev, data])
+          return data
         })
+        setCastsArray(docs)
       } catch (e) {
         console.error(e)
       }

--- a/src/lib/streamImpl.ts
+++ b/src/lib/streamImpl.ts
@@ -1,13 +1,14 @@
 import { collection, addDoc, getDocs, query } from 'firebase/firestore'
 import { db } from 'utils/firebase'
-import { QuerySnapshot, DocumentData } from '@firebase/firestore'
+import { QuerySnapshot, DocumentData, Timestamp } from '@firebase/firestore'
 
 export type TStream = {
   hee_count: number
   is_streamed: number
   title: string
-  created_at: string
-  updated_at: string
+  stream_date: Timestamp
+  created_at: Timestamp
+  updated_at: Timestamp
 }
 
 export const getStreams = async (): Promise<QuerySnapshot<DocumentData>> => {

--- a/src/pages/admin/broadcasts/create.tsx
+++ b/src/pages/admin/broadcasts/create.tsx
@@ -6,6 +6,7 @@ import { addStream } from 'lib/streamImpl'
 import type { TStream } from 'lib/streamImpl'
 import { ChangeEvent, useCallback, useState } from 'react'
 import RecoilProvider from 'components/RecoilProvider'
+import { Timestamp } from '@firebase/firestore'
 
 const CreateBroadcast: NextPage = () => {
   const [title, setTitle] = useState<string>('')
@@ -19,8 +20,9 @@ const CreateBroadcast: NextPage = () => {
       hee_count: 0,
       is_streamed: 1,
       title: title,
-      created_at: date,
-      updated_at: date
+      stream_date: Timestamp.fromDate(new Date(date)),
+      created_at: Timestamp.fromDate(new Date()),
+      updated_at: Timestamp.fromDate(new Date())
     }
     addStream(data)
   }, [title, date])
@@ -56,7 +58,7 @@ const CreateBroadcast: NextPage = () => {
               id="date"
               type="date"
               onChange={(e: ChangeEvent) => {
-                setDate(() => e.target.value as string)
+                setDate(() => e.target.value)
               }}
             />
           </div>

--- a/src/utils/formatDate.ts
+++ b/src/utils/formatDate.ts
@@ -1,0 +1,3 @@
+export const formatDate = (date: Date): string => {
+  return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDay()}日`
+}


### PR DESCRIPTION
放送のurl追加した時にupdated_atのフォーマットが変わってしまう事によって
放送一覧ページでエラーになっていました。

・日付のフォーマットの修正
・今まで放送一覧で更新日を表示してたのですが、放送日を表示しないといけない事に気づいたのでそこもスキーマを修正

# 確認
http://localhost:3000/admin/broadcasts/create で放送を作成した後
http://localhost:3000/admin/posts で放送にurlを設定
http://localhost:3000/broadcasts で放送一覧が表示できること

# 注意
Url更新時のdoc idが決め打ちなので、登録した放送のdoc idをコピペしてください。
該当箇所はlib/posts.tsの更新処理です。

closes #75