### PR TITLE
⚡️ 放送作成ボタン実装

### DIFF
--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -7,7 +7,11 @@ import Link from 'next/link'
 
 export const initialState: TCard[] = []
 
-export const Broadcasts: React.VFC = () => {
+type Props = {
+  isAdmin: boolean
+}
+
+export const Broadcasts: React.VFC<Props> = ({ isAdmin }) => {
   const [castsArray, setCastsArray] = useState<TCard[]>([])
 
   // 放送の一覧取得
@@ -32,27 +36,26 @@ export const Broadcasts: React.VFC = () => {
   }, [])
 
   return (
-    <div className="h-[calc(100vh-64px-5rem)]">
-      <div className="mx-auto w-3/5">
-        <ul className="overflow-y-auto h-[calc(100vh-64px-150px)]">
-          {castsArray.map((item) => {
-            return (
-              <li key={item.id} className="mt-[2px]">
-                <BroadcastCard {...item} />
-              </li>
-            )
-          })}
-        </ul>
-      </div>
+    <div className="mx-auto w-[700px]">
+      {isAdmin ? adminTitle() : userTitle()}
+      <ul className="overflow-y-auto h-[calc(100vh-64px-150px)]">
+        {castsArray.map((item) => {
+          return (
+            <li key={item.id} className="mt-[2px]">
+              <BroadcastCard {...item} />
+            </li>
+          )
+        })}
+      </ul>
     </div>
   )
 }
 
-export const AdminLink: React.VFC = () => {
+export const adminTitle: React.VFC = () => {
   return (
-    <div className="flex justify-center bg-gray-200">
-      <div className="mb-[30px] w-[48%] text-4xl">放送一覧</div>
-      <div className="py-[13px] px-[25px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
+    <div className="flex justify-between mb-[30px] bg-gray-200">
+      <div className="text-4xl">放送一覧</div>
+      <div className="py-[7px] px-[10px] text-[14px] text-white bg-[#0284C7] rounded-md">
         <Link href="/admin/broadcasts/create">
           <a>放送を作成する</a>
         </Link>
@@ -61,7 +64,7 @@ export const AdminLink: React.VFC = () => {
   )
 }
 
-export const UserLink: React.VFC = () => {
+export const userTitle: React.VFC = () => {
   return (
     <div className="flex justify-center bg-gray-200">
       <div className="mb-[30px] w-3/5 text-4xl">放送一覧</div>

--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -32,7 +32,7 @@ export const Broadcasts: React.VFC = () => {
 
   return (
     <div className="h-[calc(100vh-64px-5rem)]">
-      <h2 className="mx-auto mb-[30px] w-3/5 text-4xl">放送一覧</h2>
+      {/* <h2 className="mx-auto mb-[30px] w-3/5 text-4xl">放送一覧</h2> */}
       <div className="mx-auto w-3/5">
         <ul className="overflow-y-auto h-[calc(100vh-64px-150px)]">
           {castsArray.map((item) => {

--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -32,7 +32,6 @@ export const Broadcasts: React.VFC = () => {
 
   return (
     <div className="h-[calc(100vh-64px-5rem)]">
-      {/* <h2 className="mx-auto mb-[30px] w-3/5 text-4xl">放送一覧</h2> */}
       <div className="mx-auto w-3/5">
         <ul className="overflow-y-auto h-[calc(100vh-64px-150px)]">
           {castsArray.map((item) => {

--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -33,14 +33,6 @@ export const Broadcasts: React.VFC = () => {
 
   return (
     <div className="h-[calc(100vh-64px-5rem)]">
-      <div className="flex justify-center bg-gray-200">
-        <div className="mb-[30px] w-[48%] text-4xl">放送一覧</div>
-        <div className="py-[13px] px-[25px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
-          <Link href="/admin/broadcasts/create">
-            <a>放送を作成する</a>
-          </Link>
-        </div>
-      </div>
       <div className="mx-auto w-3/5">
         <ul className="overflow-y-auto h-[calc(100vh-64px-150px)]">
           {castsArray.map((item) => {
@@ -52,6 +44,27 @@ export const Broadcasts: React.VFC = () => {
           })}
         </ul>
       </div>
+    </div>
+  )
+}
+
+export const AdminLink: React.VFC = () => {
+  return (
+    <div className="flex justify-center bg-gray-200">
+      <div className="mb-[30px] w-[48%] text-4xl">放送一覧</div>
+      <div className="py-[13px] px-[25px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
+        <Link href="/admin/broadcasts/create">
+          <a>放送を作成する</a>
+        </Link>
+      </div>
+    </div>
+  )
+}
+
+export const UserLink: React.VFC = () => {
+  return (
+    <div className="flex justify-center bg-gray-200">
+      <div className="mb-[30px] w-3/5 text-4xl">放送一覧</div>
     </div>
   )
 }

--- a/src/components/Broadcasts.tsx
+++ b/src/components/Broadcasts.tsx
@@ -3,6 +3,7 @@ import { getStreams } from 'lib/streamImpl'
 import { useEffect, useState } from 'react'
 import type { TCard } from 'components/BroadcastCard'
 import { formatDate } from 'utils/formatDate'
+import Link from 'next/link'
 
 export const initialState: TCard[] = []
 
@@ -32,6 +33,14 @@ export const Broadcasts: React.VFC = () => {
 
   return (
     <div className="h-[calc(100vh-64px-5rem)]">
+      <div className="flex justify-center bg-gray-200">
+        <div className="mb-[30px] w-[48%] text-4xl">放送一覧</div>
+        <div className="py-[13px] px-[25px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
+          <Link href="/admin/broadcasts/create">
+            <a>放送を作成する</a>
+          </Link>
+        </div>
+      </div>
       <div className="mx-auto w-3/5">
         <ul className="overflow-y-auto h-[calc(100vh-64px-150px)]">
           {castsArray.map((item) => {

--- a/src/pages/admin/broadcasts/index.tsx
+++ b/src/pages/admin/broadcasts/index.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 import type { NextPage } from 'next'
-import { AdminLink, Broadcasts } from 'components/Broadcasts'
+import { Broadcasts } from 'components/Broadcasts'
 import RecoilProvider from 'components/RecoilProvider'
 
 const BroadcastsIndex: NextPage = () => {
@@ -9,8 +9,7 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
-      <AdminLink />
-      <Broadcasts />
+      <Broadcasts isAdmin={true} />
     </>
   )
 }

--- a/src/pages/admin/broadcasts/index.tsx
+++ b/src/pages/admin/broadcasts/index.tsx
@@ -10,14 +10,6 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
-      <div className="flex justify-center bg-gray-200">
-        <div className="mb-[30px] w-1/2 text-4xl">放送一覧</div>
-        <div className="py-[13px] px-[25px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
-          <Link href="/admin/broadcasts/create">
-            <a>放送を作成する</a>
-          </Link>
-        </div>
-      </div>
       <Broadcasts />
     </>
   )

--- a/src/pages/admin/broadcasts/index.tsx
+++ b/src/pages/admin/broadcasts/index.tsx
@@ -10,14 +10,14 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
-      <Broadcasts />
-      <div className="flex justify-center bg-gray-200">
+      <div className="flex justify-end w-4/5 bg-gray-200">
         <div className="py-[13px] px-[25px] mt-[32px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
           <Link href="/admin/broadcasts/create">
             <a>放送を作成する</a>
           </Link>
         </div>
       </div>
+      <Broadcasts />
     </>
   )
 }

--- a/src/pages/admin/broadcasts/index.tsx
+++ b/src/pages/admin/broadcasts/index.tsx
@@ -1,8 +1,7 @@
 import Head from 'next/head'
 import type { NextPage } from 'next'
-import { Broadcasts } from 'components/Broadcasts'
+import { AdminLink, Broadcasts } from 'components/Broadcasts'
 import RecoilProvider from 'components/RecoilProvider'
-import Link from 'next/link'
 
 const BroadcastsIndex: NextPage = () => {
   return (
@@ -10,6 +9,7 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
+      <AdminLink />
       <Broadcasts />
     </>
   )

--- a/src/pages/admin/broadcasts/index.tsx
+++ b/src/pages/admin/broadcasts/index.tsx
@@ -10,8 +10,9 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
-      <div className="flex justify-end w-4/5 bg-gray-200">
-        <div className="py-[13px] px-[25px] mt-[32px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
+      <div className="flex justify-center bg-gray-200">
+        <div className="mb-[30px] w-1/2 text-4xl">放送一覧</div>
+        <div className="py-[13px] px-[25px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
           <Link href="/admin/broadcasts/create">
             <a>放送を作成する</a>
           </Link>

--- a/src/pages/admin/broadcasts/index.tsx
+++ b/src/pages/admin/broadcasts/index.tsx
@@ -1,0 +1,29 @@
+import Head from 'next/head'
+import type { NextPage } from 'next'
+import { Broadcasts } from 'components/Broadcasts'
+import RecoilProvider from 'components/RecoilProvider'
+import Link from 'next/link'
+
+const BroadcastsIndex: NextPage = () => {
+  return (
+    <>
+      <Head>
+        <title>放送一覧ページ</title>
+      </Head>
+      <Broadcasts />
+      <div className="flex justify-center bg-gray-200">
+        <div className="py-[13px] px-[25px] mt-[32px] w-[162px] h-[50px] text-[16px] text-white bg-[#0284C7] rounded-md">
+          <Link href="/admin/broadcasts/create">
+            <a>放送を作成する</a>
+          </Link>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default BroadcastsIndex
+
+BroadcastsIndex.getLayout = (page) => {
+  return <RecoilProvider>{page}</RecoilProvider>
+}

--- a/src/pages/broadcasts/index.tsx
+++ b/src/pages/broadcasts/index.tsx
@@ -9,8 +9,7 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
-      <UserLink />
-      <Broadcasts />
+      <Broadcasts isAdmin={false} />
     </>
   )
 }

--- a/src/pages/broadcasts/index.tsx
+++ b/src/pages/broadcasts/index.tsx
@@ -9,9 +9,6 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
-      <div className="flex text-center">
-        <div className="mb-[30px] w-1/2 text-4xl">放送一覧</div>
-      </div>
       <Broadcasts />
     </>
   )

--- a/src/pages/broadcasts/index.tsx
+++ b/src/pages/broadcasts/index.tsx
@@ -1,6 +1,6 @@
 import Head from 'next/head'
 import type { NextPage } from 'next'
-import { Broadcasts } from 'components/Broadcasts'
+import { Broadcasts, UserLink } from 'components/Broadcasts'
 import RecoilProvider from 'components/RecoilProvider'
 
 const BroadcastsIndex: NextPage = () => {
@@ -9,6 +9,7 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
+      <UserLink />
       <Broadcasts />
     </>
   )

--- a/src/pages/broadcasts/index.tsx
+++ b/src/pages/broadcasts/index.tsx
@@ -9,6 +9,9 @@ const BroadcastsIndex: NextPage = () => {
       <Head>
         <title>放送一覧ページ</title>
       </Head>
+      <div className="flex text-center">
+        <div className="mb-[30px] w-1/2 text-4xl">放送一覧</div>
+      </div>
       <Broadcasts />
     </>
   )


### PR DESCRIPTION
アドミン側の放送一覧ページを作成しました。(Figma上の21,23,,31,32です)
 -  ユーザ側のコードを基に、「放送を作成する」のリンクを下部に作成しました。
 (ブランチ名に「-2」と付いていますが、ブランチ作成時の誤りです。)

ご指摘お願いします。